### PR TITLE
fix(): fix dependencies or plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<repository>
 			<id>spring-release</id>
 			<name>Spring release</name>
-			<url>https://repo.spring.io/release</url>
+			<url>https://repo.spring.io/ui/native/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -94,7 +94,7 @@
 		<pluginRepository>
 			<id>spring-release</id>
 			<name>Spring release</name>
-			<url>https://repo.spring.io/release</url>
+			<url>https://repo.spring.io/ui/native/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>spring-milestone</id>
@@ -140,7 +140,9 @@
 		<spring-boot.version>2.7.14</spring-boot.version>
 		<spring-boot-maven-plugin.version>${spring-boot.version}
 		</spring-boot-maven-plugin.version>
-		<springdoc.version>1.8.0</springdoc.version>
+		<!-- Next version doesn't exist	-->
+<!--		<springdoc.version>1.8.0</springdoc.version>-->
+		<springdoc.version>1.7.0</springdoc.version>
 		<maven-source-plugin.version>3.0.1</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>

--- a/springdoc-openapi-book-service/README.md
+++ b/springdoc-openapi-book-service/README.md
@@ -1,4 +1,4 @@
 ### Relevant Articles:
 
-- [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
-
+* [Outdated] [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
+  * Not valid anymore

--- a/springdoc-openapi-book-service/README.md
+++ b/springdoc-openapi-book-service/README.md
@@ -1,5 +1,4 @@
 ### Relevant Articles:
 
-* [Updated to the new version] [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
-  * Not valid anymore
+- [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
 

--- a/springdoc-openapi-book-service/README.md
+++ b/springdoc-openapi-book-service/README.md
@@ -1,4 +1,5 @@
 ### Relevant Articles:
 
-- [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
+* [Updated to the new version] [Documenting a Spring REST API Using OpenAPI 3.0](https://www.baeldung.com/spring-rest-openapi-documentation)
+  * Not valid anymore
 

--- a/springdoc-openapi-book-service/pom.xml
+++ b/springdoc-openapi-book-service/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.7.0</version>
 		</dependency>
 	</dependencies>
 	<build>


### PR DESCRIPTION
Hello!! 

* In the v3.1.5, I am getting problems to download org.springdoc:springdoc-openapi:1.8.0
  * Checking official mvn repository, that release version doesn't exist -- [Link](https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi) --

`org/springdoc/springdoc-openapi/1.8.0/springdoc-openapi-1.8.0.pom: unexpected markup <!d (position: START_DOCUMENT seen <!d... @1:3) `

* Update Spring PluginRepository urls

  