### PR TITLE
Add non Spring Boot Spring Web MVC demo for springdoc (#67)

### DIFF
--- a/demo-spring-webmvc-nonboot/README.md
+++ b/demo-spring-webmvc-nonboot/README.md
@@ -1,0 +1,37 @@
+# springdoc-openapi demo with non Spring Boot Spring Web MVC
+
+## Building application
+
+### Pre-requisites
+
+- JDK 17+
+- Maven 3+
+
+### Build
+
+From the project root:
+
+```sh
+mvn -pl demo-spring-webmvc-nonboot -am clean package
+```
+
+This will produce:
+
+```text
+demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot.war
+```
+
+
+## Run
+
+Deploy the generated WAR to a Servlet container (e.g. Tomcat).
+
+Assuming the context path is /demo-spring-webmvc-nonboot:
+
+- OpenAPI docs: /demo-spring-webmvc-nonboot/v3/api-docs
+- Swagger UI: /demo-spring-webmvc-nonboot/swagger-ui/index.html
+- Sample API: GET /demo-spring-webmvc-nonboot/api/hello
+
+
+This is a Maven module.  
+Build it together with the other demos using your preferred Maven setup or IDE.

--- a/demo-spring-webmvc-nonboot/pom.xml
+++ b/demo-spring-webmvc-nonboot/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-demos</artifactId>
+        <version>3.1.7-SNAPSHOT</version> <!-- 루트 pom 버전과 동일하게 -->
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>demo-spring-webmvc-nonboot</artifactId>
+    <name>Demo Spring Web MVC (non Spring Boot) with OpenAPI 3</name>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>demo-spring-webmvc-nonboot</finalName>
+        <plugins>
+
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- LOCAL TEST ONLY: Jetty to run the WAR, do NOT commit if maintainers don't want it -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>11.0.26</version>
+                <configuration>
+                    <webApp>
+                        <contextPath>/demo-spring-webmvc-nonboot</contextPath>
+                    </webApp>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/demo-spring-webmvc-nonboot/src/main/java/org/springdoc/demo/nonboot/config/OpenApiConfiguration.java
+++ b/demo-spring-webmvc-nonboot/src/main/java/org/springdoc/demo/nonboot/config/OpenApiConfiguration.java
@@ -1,0 +1,45 @@
+package org.springdoc.demo.nonboot.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+import org.springdoc.webmvc.ui.SwaggerConfig;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+@Configuration
+@EnableWebMvc
+@ComponentScan(basePackages = {
+        "org.springdoc.demo.nonboot.web"
+})
+@Import({
+        SpringDocConfiguration.class,
+        SpringDocWebMvcConfiguration.class,
+        SwaggerConfig.class,
+        SwaggerUiConfigProperties.class,
+        SwaggerUiOAuthProperties.class,
+        JacksonAutoConfiguration.class
+})
+public class OpenApiConfiguration {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Non Spring Boot Spring MVC demo API")
+                        .version("v1"));
+    }
+
+    @Bean
+    public SpringDocConfigProperties springDocConfigProperties() {
+        return new SpringDocConfigProperties();
+    }
+}

--- a/demo-spring-webmvc-nonboot/src/main/java/org/springdoc/demo/nonboot/web/HelloController.java
+++ b/demo-spring-webmvc-nonboot/src/main/java/org/springdoc/demo/nonboot/web/HelloController.java
@@ -1,0 +1,20 @@
+package org.springdoc.demo.nonboot.web;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Hello API", description = "Simple demo endpoint for non-boot Spring MVC")
+public class HelloController {
+
+    @GetMapping("/api/hello")
+    @Operation(summary = "Say hello", description = "Returns a simple greeting")
+    public Greeting hello() {
+        return new Greeting("Hello from non Spring Boot Spring MVC application!");
+    }
+
+    public record Greeting(String message) {
+    }
+}

--- a/demo-spring-webmvc-nonboot/src/main/webapp/WEB-INF/web.xml
+++ b/demo-spring-webmvc-nonboot/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <display-name>springdoc non-boot spring-webmvc demo</display-name>
+
+    <servlet>
+        <servlet-name>dispatcher</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+
+        <init-param>
+            <param-name>contextClass</param-name>
+            <param-value>org.springframework.web.context.support.AnnotationConfigWebApplicationContext</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>org.springdoc.demo.nonboot.config.OpenApiConfiguration</param-value>
+        </init-param>
+
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>dispatcher</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/MANIFEST.MF
+++ b/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Created-By: Maven WAR Plugin 3.4.0
+Build-Jdk-Spec: 21
+Implementation-Title: Demo Spring Web MVC (non Spring Boot) with OpenAPI
+  3
+Implementation-Version: 3.1.7-SNAPSHOT
+

--- a/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/maven/org.springdoc/demo-spring-webmvc-nonboot/pom.properties
+++ b/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/maven/org.springdoc/demo-spring-webmvc-nonboot/pom.properties
@@ -1,0 +1,3 @@
+artifactId=demo-spring-webmvc-nonboot
+groupId=org.springdoc
+version=3.1.7-SNAPSHOT

--- a/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/maven/org.springdoc/demo-spring-webmvc-nonboot/pom.xml
+++ b/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/META-INF/maven/org.springdoc/demo-spring-webmvc-nonboot/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-demos</artifactId>
+        <version>3.1.7-SNAPSHOT</version> <!-- 루트 pom 버전과 동일하게 -->
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>demo-spring-webmvc-nonboot</artifactId>
+    <name>Demo Spring Web MVC (non Spring Boot) with OpenAPI 3</name>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>demo-spring-webmvc-nonboot</finalName>
+        <plugins>
+
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <!-- LOCAL TEST ONLY: Jetty to run the WAR, do NOT commit if maintainers don't want it -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>11.0.26</version>
+                <configuration>
+                    <webApp>
+                        <contextPath>/demo-spring-webmvc-nonboot</contextPath>
+                    </webApp>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>false</failOnMissingWebXml>
+                </configuration>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/WEB-INF/web.xml
+++ b/demo-spring-webmvc-nonboot/target/demo-spring-webmvc-nonboot/WEB-INF/web.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+
+    <display-name>springdoc non-boot spring-webmvc demo</display-name>
+
+    <servlet>
+        <servlet-name>dispatcher</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+
+        <init-param>
+            <param-name>contextClass</param-name>
+            <param-value>org.springframework.web.context.support.AnnotationConfigWebApplicationContext</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value>org.springdoc.demo.nonboot.config.OpenApiConfiguration</param-value>
+        </init-param>
+
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>dispatcher</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/demo-spring-webmvc-nonboot/target/maven-archiver/pom.properties
+++ b/demo-spring-webmvc-nonboot/target/maven-archiver/pom.properties
@@ -1,0 +1,3 @@
+artifactId=demo-spring-webmvc-nonboot
+groupId=org.springdoc
+version=3.1.7-SNAPSHOT

--- a/demo-spring-webmvc-nonboot/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
+++ b/demo-spring-webmvc-nonboot/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst
@@ -1,0 +1,3 @@
+org\springdoc\demo\nonboot\config\OpenApiConfiguration.class
+org\springdoc\demo\nonboot\web\HelloController.class
+org\springdoc\demo\nonboot\web\HelloController$Greeting.class

--- a/demo-spring-webmvc-nonboot/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
+++ b/demo-spring-webmvc-nonboot/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst
@@ -1,0 +1,2 @@
+D:\backup01\Documents\GitHub\springdoc-openapi-demos\demo-spring-webmvc-nonboot\src\main\java\org\springdoc\demo\nonboot\config\OpenApiConfiguration.java
+D:\backup01\Documents\GitHub\springdoc-openapi-demos\demo-spring-webmvc-nonboot\src\main\java\org\springdoc\demo\nonboot\web\HelloController.java

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<module>demo-spring-cloud-function</module>
 		<module>demo-spring-boot-webflux-scalar</module>
 		<module>demo-spring-boot-webmvc-scalar</module>
+		<module>demo-spring-webmvc-nonboot</module>
 	</modules>
 
 	<properties>


### PR DESCRIPTION
This PR adds a new demo module: `demo-spring-webmvc-nonboot`.

It addresses issue #67 by providing a working sample for using
springdoc-openapi in a classic Spring Web MVC application **without**
a Spring Boot application class.

### Highlights

- New module `demo-spring-webmvc-nonboot` (WAR packaging)
- `DispatcherServlet` configured via `web.xml`
- Java config `OpenApiConfiguration`:
  - enables `@EnableWebMvc`
  - imports `SpringDocConfiguration`, `SpringDocWebMvcConfiguration`,
    `SwaggerConfig` and `JacksonAutoConfiguration`
  - explicitly registers a `SpringDocConfigProperties` bean
- Sample `HelloController` exposing `GET /api/hello`
- Module-level README describing how to build and deploy the demo

The demo was verified locally by deploying the generated WAR
to a Servlet container and accessing:

- `/v3/api-docs`
- `/swagger-ui/index.html`
- `/api/hello`

Fixes #67.